### PR TITLE
[Bugfix] - Use `mailto` in crossref requests

### DIFF
--- a/src/paper_feeds/config.py
+++ b/src/paper_feeds/config.py
@@ -7,7 +7,7 @@ class Config(BaseSettings):
     model_config = SettingsConfigDict(
         env_file='.env',
         env_file_encoding='utf-8',
-        env_prefix="jrss_")
+        env_prefix="paperfeeds_")
 
     db: Optional[Path] = Path('./db.sqlite')
     """

--- a/src/paper_feeds/services/crossref.py
+++ b/src/paper_feeds/services/crossref.py
@@ -1,4 +1,3 @@
-import pdb
 from typing import Optional, List, Generator
 from datetime import datetime
 
@@ -29,15 +28,32 @@ See http://api.crossref.org/types
 
 def crossref_get(
         endpoint: str,
-        params:dict,
-        contact: Optional[Config] = None
+        params: dict,
+        email: str = None
 ) -> requests.Response:
+    """
+    .. todo::
+
+        Document this
+
+    Args:
+        endpoint (str): Endpoint appended to :data:`.CROSSREF_API_URL`
+        params (dict): Query parameters
+        email (str): Email used to be `polite to crossref <https://github.com/CrossRef/rest-api-doc#good-manners--more-reliable-service>`_
+            If ``None`` , use ``crossref_email`` set in :class:`.Config`
+
+    Returns:
+        :class:`requests.Response`
+    """
     headers = {
         'User-Agent': USER_AGENT
     }
-    if contact:
+    if email is None:
+        email = Config().crossref_email
+
+    if email:
         params.update({
-            'mailto': contact
+            'mailto': email
         })
     return requests.get(
         CROSSREF_API_URL + endpoint,

--- a/src/paper_feeds/services/crossref.py
+++ b/src/paper_feeds/services/crossref.py
@@ -29,7 +29,7 @@ See http://api.crossref.org/types
 def crossref_get(
         endpoint: str,
         params: dict,
-        email: str = None
+        email: Optional[str] = None
 ) -> requests.Response:
     """
     .. todo::

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -1,9 +1,49 @@
 import pdb
+import os
 from .fixtures import db_tables, memory_db
+from urllib.parse import urlparse, parse_qs
 
 import pytest
 
-from paper_feeds.services.crossref import fetch_paper_page, fetch_papers, journal_search, store_journal
+from paper_feeds import Config
+from paper_feeds.services.crossref import (
+    crossref_get,
+    fetch_paper_page,
+    fetch_papers,
+    journal_search,
+    store_journal
+)
+
+def test_crossref_get_mailto():
+    """
+    Use the mailto parameter to be polite to crossref
+
+    .. todo::
+
+        make fixture to parameterize config
+
+    .. todo::
+
+        this one definitely needs to be vcr'd
+
+    """
+    # first should be able to not use an email if we don't want
+    res = crossref_get('journals', params={'query': 'Neuron'}, email=None)
+    params = parse_qs(urlparse(res.url).query)
+    assert 'mailto' not in params
+
+    # now we should add an email if asked to explicitly
+    email = 'tests@example.com'
+    res = crossref_get('journals', params={'query': 'Neuron'}, email=email)
+    params = parse_qs(urlparse(res.url).query)
+    assert params['mailto'][0] == email
+
+    # and via .env (which should be tested separately)
+    os.environ['PAPERFEEDS_CROSSREF_EMAIL'] = email
+    res = crossref_get('journals', params={'query': 'Neuron'}, email=None)
+    params = parse_qs(urlparse(res.url).query)
+    assert params['mailto'][0] == email
+
 
 @pytest.mark.parametrize(
     'query,issn',

--- a/tests/test_crossref.py
+++ b/tests/test_crossref.py
@@ -109,7 +109,7 @@ def test_fetch_papers(issn, limit):
         all_papers.extend(papers)
     assert len(all_papers) == limit
 
-@pytest.mark.timeout(10)
+@pytest.mark.timeout(20)
 def test_fetch_less_than_limit():
     """Fetch less than the limit without doing an infinite loop about it"""
     for papers in fetch_papers('2666-0539', limit=1000):


### PR DESCRIPTION
Fix: https://github.com/sneakers-the-rat/paper-feeds/issues/29 

Use the crossref email config value when it is set in Config but not explicitly passed!